### PR TITLE
Require aiohttp>=3.8.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["aiohttp>=3.9", "music_assistant_models==1.1.9", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.9", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"


### PR DESCRIPTION
This PR drops aiohttp requirement from 3.9 to 3.8.6 (the last of 3.8.X, released on 2023-10-07).

Did some testing, it seems to work fine. This will only affect cases where the client is installed together with older packages that cannot work with 3.9. It will not affect the client's use within the MA server or integration at all.

The main use-case is to use the client in AppDaemon (which requires aiohttp<3.9), which is  a reasonable application to allow flexibility in controlling MA.