### PR TITLE
Fix wrong `play_pause` command endpoint

### DIFF
--- a/music_assistant_client/players.py
+++ b/music_assistant_client/players.py
@@ -73,7 +73,7 @@ class Players:
 
     async def play_pause(self, player_id: str) -> None:
         """Send PLAY_PAUSE (toggle) command to given player (directly)."""
-        await self.client.send_command("players/cmd/pause", player_id=player_id)
+        await self.client.send_command("players/cmd/play_pause", player_id=player_id)
 
     async def power(self, player_id: str, powered: bool) -> None:
         """Send POWER command to given player."""


### PR DESCRIPTION
The `Players#play_pause` method was calling the `players/cmd/pause` command, likely a copy-paste error. This PR fixes that.