### PR TITLE
Fix auth/login body structure in auth_helpers.py

### DIFF
--- a/music_assistant_client/auth_helpers.py
+++ b/music_assistant_client/auth_helpers.py
@@ -65,7 +65,7 @@ async def login(
         # Send login request
         async with session.post(
             f"{server_url}auth/login",
-            json={"username": username, "password": password},
+            json={"credentials": {"username": username, "password": password}},
         ) as response:
             if response.status == 401:
                 msg = "Invalid username or password"


### PR DESCRIPTION
Fixes `login()` in `auth_helpers.py` so it sends credentials in the format the server actually expects.

The `login()` helper was sending credentials flat in the request body:

```json
{"username": "loopj", "password": "hunter2"}
```

The server, however, expects them to be nested under a `credentials` key:

```json
{"credentials": {"username": "loopj", "password": "hunter2"}}
```

Since music-assistant/server#2684, the server's `_handle_auth_login` has read them from a nested key:

```python
credentials = body.get("credentials", {})
```

It seems like the client was never update to match this change.