### PR TITLE
Use the new opaque-id imageproxy URL format on schema 31+ servers

### DIFF
--- a/music_assistant_client/client.py
+++ b/music_assistant_client/client.py
@@ -173,7 +173,9 @@ class MusicAssistantClient:
                 f"&w=${size}&h=${size}&fit=cover&a=attention"
             )
         # return imageproxy url for images that need to be resolved
-        # the original path is double encoded
+        if self.server_info.schema_version >= 31 and image.proxy_id:
+            return f"{self.server_info.base_url}/imageproxy/{image.proxy_id}?size={size}"
+        # legacy form: the original path is double encoded
         encoded_url = urllib.parse.quote(urllib.parse.quote(image.path))
         return (
             f"{self.server_info.base_url}/imageproxy?path={encoded_url}"

--- a/music_assistant_client/constants.py
+++ b/music_assistant_client/constants.py
@@ -2,4 +2,4 @@
 
 from typing import Final
 
-API_SCHEMA_VERSION: Final[int] = 28
+API_SCHEMA_VERSION: Final[int] = 31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.115", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.123", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.123", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.124", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"


### PR DESCRIPTION
## Summary

[music-assistant/server#3960](https://github.com/music-assistant/server/pull/3960) replaces the long, double-encoded `/imageproxy?provider=&path=` URL with a short opaque-id form `/imageproxy/<proxy_id>?size=&fmt=`. The server bumps `API_SCHEMA_VERSION` to 31 and injects `proxy_id` on every `MediaItemImage` during outbound serialization (via [music-assistant/models#233](https://github.com/music-assistant/models/pull/233)). The client needs to consume that new field and build the new URL when talking to a schema 31+ server.

## Changes

- `get_image_url()` now returns the new `/imageproxy/<proxy_id>?size=` URL when `server_info.schema_version >= 31` and the image has a `proxy_id`. Falls back to the legacy double-encoded form for older servers (server still supports it for back-compat).
- Bumped `API_SCHEMA_VERSION` to `31`.
- Bumped `music_assistant_models` pin to `1.1.123` (first release with the `proxy_id` field on `MediaItemImage`).