### PR TITLE
Remove deprecated SyncTask usage

### DIFF
--- a/music_assistant_client/music.py
+++ b/music_assistant_client/music.py
@@ -24,7 +24,6 @@ from music_assistant_models.media_items import (
     Track,
     media_from_dict,
 )
-from music_assistant_models.provider import SyncTask
 
 if TYPE_CHECKING:
     from music_assistant_models.queue_item import QueueItem
@@ -574,10 +573,6 @@ class Music:
         providers: only sync these provider instances. None for all.
         """
         await self.client.send_command("music/sync", media_types=media_types, providers=providers)
-
-    async def get_running_sync_tasks(self) -> list[SyncTask]:
-        """Return list with providers that are currently (scheduled for) syncing."""
-        return [SyncTask(**item) for item in await self.client.send_command("music/synctasks")]
 
     async def search(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.115", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.133", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"


### PR DESCRIPTION
The server no longer exposes the `music/synctasks` command — provider sync jobs are now reported as `BackgroundTask`s. The client's `get_running_sync_tasks()` called that non-existent command, so it was dead/broken code. The `SyncTask` model has also been removed from `music_assistant_models`.

- Remove `get_running_sync_tasks()` and the `SyncTask` import
- Bump `music_assistant_models` to `1.1.133` (drops `SyncTask`)
