### PR TITLE
Sync client with server API (schema 33)

### DIFF
--- a/music_assistant_client/auth.py
+++ b/music_assistant_client/auth.py
@@ -72,6 +72,8 @@ class Auth:
         role: str = "user",
         display_name: str | None = None,
         avatar_url: str | None = None,
+        player_filter: list[str] | None = None,
+        provider_filter: list[str] | None = None,
     ) -> User:
         """Create a new user with built-in authentication (admin only)."""
         return User.from_dict(
@@ -82,6 +84,8 @@ class Auth:
                 role=role,
                 display_name=display_name,
                 avatar_url=avatar_url,
+                player_filter=player_filter,
+                provider_filter=provider_filter,
             )
         )
 
@@ -104,9 +108,14 @@ class Auth:
             for provider in await self.client.send_command("auth/user/providers")
         ]
 
-    async def unlink_provider(self, link_id: str) -> None:
+    async def unlink_provider(self, user_id: str, provider_type: str) -> bool:
         """Unlink authentication provider from user (admin only)."""
-        await self.client.send_command("auth/user/unlink_provider", link_id=link_id)
+        result: bool = await self.client.send_command(
+            "auth/user/unlink_provider",
+            user_id=user_id,
+            provider_type=provider_type,
+        )
+        return result
 
     async def update_user(
         self,
@@ -115,9 +124,10 @@ class Auth:
         display_name: str | None = None,
         avatar_url: str | None = None,
         password: str | None = None,
-        old_password: str | None = None,
         role: str | None = None,
         preferences: dict[str, Any] | None = None,
+        player_filter: list[str] | None = None,
+        provider_filter: list[str] | None = None,
     ) -> User:
         """
         Update user profile information.
@@ -130,9 +140,11 @@ class Auth:
             display_name: New display name (optional)
             avatar_url: New avatar URL (optional)
             password: New password (optional, minimum 8 characters)
-            old_password: Current password (required when user updates own password)
             role: New role - "admin" or "user" (optional, admin only)
             preferences: User preferences dict (completely replaces existing, optional)
+            player_filter: List of player IDs the user has access to (admin only, optional)
+            provider_filter: List of provider instance IDs the user has access to
+                (admin only, optional)
 
         Returns:
             Updated user object
@@ -145,9 +157,10 @@ class Auth:
                 display_name=display_name,
                 avatar_url=avatar_url,
                 password=password,
-                old_password=old_password,
                 role=role,
                 preferences=preferences,
+                player_filter=player_filter,
+                provider_filter=provider_filter,
             )
         )
 

--- a/music_assistant_client/client.py
+++ b/music_assistant_client/client.py
@@ -59,6 +59,7 @@ class MusicAssistantClient:
         aiohttp_session: ClientSession | None,
         token: str | None = None,
         ssl_context: SSLContext | None = None,
+        locale: str | None = None,
     ) -> None:
         """
         Initialize the Music Assistant client.
@@ -69,10 +70,13 @@ class MusicAssistantClient:
             token: Optional authentication token (required for schema >= 28)
             ssl_context: Optional SSL context for HTTPS connections. Use this for
                 custom CA certificates or self-signed certificates.
+            locale: Optional UI locale (e.g. "nl" or "de_DE") to declare to the server
+                (requires schema >= 33). Used to localize server-provided strings.
         """
         self.server_url = server_url
         self.connection = WebsocketsConnection(server_url, aiohttp_session, token, ssl_context)
         self.logger = logging.getLogger(__package__)
+        self._locale = locale
         self._result_futures: dict[str | int, asyncio.Future[Any]] = {}
         # buffer for chunked/streamed (partial) command results, keyed by message_id
         self._partial_results: dict[str | int, list[Any]] = {}
@@ -263,7 +267,11 @@ class MusicAssistantClient:
             # Send authentication command using send_command
             # (works without start_listening since send_command handles responses directly)
             try:
-                result = await self.send_command("auth", token=self.connection.auth_token)
+                auth_args: dict[str, Any] = {"token": self.connection.auth_token}
+                # the UI locale can be declared with the auth command (schema >= 33)
+                if info.schema_version >= 33 and self._locale:
+                    auth_args["locale"] = self._locale
+                result = await self.send_command("auth", **auth_args)
             except Exception as err:
                 await self.connection.disconnect()
                 if isinstance(err, AuthenticationFailed):
@@ -373,6 +381,29 @@ class MusicAssistantClient:
             args=kwargs,
         )
         await self.connection.send_message(command_message.to_dict())
+
+    async def get_locales(self) -> list[str]:
+        """Return the list of available UI locales (sorted)."""
+        result: list[str] = await self.send_command(
+            "translations/locales",
+            require_schema=33,
+        )
+        return result
+
+    async def set_locale(self, locale: str) -> None:
+        """
+        Set the UI locale for this connection (e.g. "nl" or "de_DE").
+
+        Used to localize server-provided strings (config entries, provider manifests
+        and localizable media item names) for subsequent commands on this connection.
+        """
+        await self.send_command(
+            "translations/set_locale",
+            locale=locale,
+            require_schema=33,
+        )
+        # remember the locale so it is re-applied automatically on reconnect
+        self._locale = locale
 
     async def start_listening(self, init_ready: asyncio.Event | None = None) -> None:
         """Connect (if needed) and start listening to incoming messages from the server."""

--- a/music_assistant_client/config.py
+++ b/music_assistant_client/config.py
@@ -51,12 +51,20 @@ class Config:
             await self.client.send_command("config/providers/get", instance_id=instance_id)
         )
 
-    async def get_provider_config_value(self, instance_id: str, key: str) -> ConfigValueType:
+    async def get_provider_config_value(
+        self,
+        instance_id: str,
+        key: str,
+        default: ConfigValueType = None,
+    ) -> ConfigValueType:
         """Return single configentry value for a provider."""
         return cast(
             "ConfigValueType",
             await self.client.send_command(
-                "config/providers/get_value", instance_id=instance_id, key=key
+                "config/providers/get_value",
+                instance_id=instance_id,
+                key=key,
+                default=default,
             ),
         )
 
@@ -125,15 +133,21 @@ class Config:
     # Player Config related commands/functions
 
     async def get_player_configs(
-        self, provider: str | None = None, include_values: bool = False
+        self,
+        provider: str | None = None,
+        include_values: bool = False,
+        include_unavailable: bool = True,
+        include_disabled: bool = True,
     ) -> list[PlayerConfig]:
-        """Return all known player configurations, optionally filtered by provider domain."""
+        """Return all known player configurations, optionally filtered by provider id."""
         return [
             PlayerConfig.from_dict(item)
             for item in await self.client.send_command(
                 "config/players",
                 provider=provider,
                 include_values=include_values,
+                include_unavailable=include_unavailable,
+                include_disabled=include_disabled,
             )
         ]
 
@@ -147,12 +161,18 @@ class Config:
         self,
         player_id: str,
         key: str,
+        default: ConfigValueType = None,
+        unpack_splitted_values: bool = False,
     ) -> ConfigValueType:
         """Return single configentry value for a player."""
         return cast(
             "ConfigValueType",
             await self.client.send_command(
-                "config/players/get_value", player_id=player_id, key=key
+                "config/players/get_value",
+                player_id=player_id,
+                key=key,
+                default=default,
+                unpack_splitted_values=unpack_splitted_values,
             ),
         )
 
@@ -191,11 +211,21 @@ class Config:
             )
         )
 
-    async def get_core_config_value(self, domain: str, key: str) -> ConfigValueType:
+    async def get_core_config_value(
+        self,
+        domain: str,
+        key: str,
+        default: ConfigValueType = None,
+    ) -> ConfigValueType:
         """Return single configentry value for a core controller."""
         return cast(
             "ConfigValueType",
-            await self.client.send_command("config/core/get_value", domain=domain, key=key),
+            await self.client.send_command(
+                "config/core/get_value",
+                domain=domain,
+                key=key,
+                default=default,
+            ),
         )
 
     async def get_core_config_entries(

--- a/music_assistant_client/constants.py
+++ b/music_assistant_client/constants.py
@@ -2,4 +2,4 @@
 
 from typing import Final
 
-API_SCHEMA_VERSION: Final[int] = 31
+API_SCHEMA_VERSION: Final[int] = 33

--- a/music_assistant_client/metadata.py
+++ b/music_assistant_client/metadata.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from music_assistant_models.media_items import media_from_dict
+from music_assistant_models.media_items import MediaItemPalette, media_from_dict
 
 if TYPE_CHECKING:
-    from music_assistant_models.media_items import MediaItemType
+    from music_assistant_models.media_items import MediaItemImage, MediaItemType
 
     from .client import MusicAssistantClient
 
@@ -50,3 +50,20 @@ class Metadata:
                 )
             ),
         )
+
+    async def get_image_palette(
+        self,
+        image: MediaItemImage | str,
+    ) -> MediaItemPalette | None:
+        """
+        Get the color palette extracted from an image.
+
+        :param image: A MediaItemImage to read colors from, or an image URL (either a
+            direct URL or an imageproxy URL as produced by `get_image_url`).
+        """
+        result = await self.client.send_command(
+            "metadata/get_image_palette",
+            image=image,
+            require_schema=32,
+        )
+        return MediaItemPalette.from_dict(result) if result else None

--- a/music_assistant_client/music.py
+++ b/music_assistant_client/music.py
@@ -612,21 +612,54 @@ class Music:
         ]
 
     async def recently_played(
-        self, limit: int = 10, media_types: list[MediaType] | None = None
+        self,
+        limit: int = 10,
+        media_types: list[MediaType] | None = None,
+        userid: str | None = None,
+        queue_id: str | None = None,
+        fully_played_only: bool = True,
+        user_initiated_only: bool = False,
+        played_after_timestamp: int | None = None,
     ) -> list[ItemMapping]:
-        """Return a list of the last played items."""
+        """
+        Return a list of the last played items.
+
+        :param limit: Maximum number of items to return.
+        :param media_types: Filter by media types.
+        :param userid: Optionally return the history of this user (instead of the user the
+            client is authenticated as). Requires the authenticated client to have sufficient
+            permissions.
+        :param queue_id: Filter by specific queue ID.
+        :param fully_played_only: If True, only return fully played items.
+        :param user_initiated_only: If True, only return items initiated by the user.
+        :param played_after_timestamp: If set, only return items played at or after this
+            epoch-seconds timestamp.
+        """
         return [
             ItemMapping.from_dict(item)
             for item in await self.client.send_command(
-                "music/recently_played_items", limit=limit, media_types=media_types
+                "music/recently_played_items",
+                limit=limit,
+                media_types=media_types,
+                userid=userid,
+                queue_id=queue_id,
+                fully_played_only=fully_played_only,
+                user_initiated_only=user_initiated_only,
+                played_after_timestamp=played_after_timestamp,
             )
         ]
 
-    async def in_progress_items(self, limit: int = 10) -> list[ItemMapping]:
+    async def in_progress_items(
+        self, limit: int = 10, all_users: bool = False
+    ) -> list[ItemMapping]:
         """Return a list of the Audiobooks and PodcastEpisodes that are in progress."""
         return [
             ItemMapping.from_dict(item)
-            for item in await self.client.send_command("music/in_progress_items", limit=limit)
+            for item in await self.client.send_command(
+                "music/in_progress_items",
+                limit=limit,
+                all_users=all_users,
+            )
         ]
 
     async def recommendations(self) -> list[RecommendationFolder]:
@@ -642,6 +675,24 @@ class Music:
     ) -> MediaItemType | ItemMapping:
         """Get single music item providing a mediaitem uri."""
         return media_from_dict(await self.client.send_command("music/item_by_uri", uri=uri))
+
+    async def verify_item_uri(self, uri: str, username: str | None = None) -> bool:
+        """
+        Verify whether a uri points to a valid, accessible item.
+
+        :param username: Optionally verify access on behalf of this user (instead of the
+            user the client is authenticated as). Requires the authenticated client to have
+            sufficient permissions.
+        """
+        return cast(
+            "bool",
+            await self.client.send_command(
+                "music/verify_item_uri",
+                uri=uri,
+                username=username,
+                require_schema=33,
+            ),
+        )
 
     async def get_item(
         self,
@@ -685,17 +736,17 @@ class Music:
     async def remove_item_from_favorites(
         self,
         media_type: MediaType,
-        item_id: str | int,
+        library_item_id: str | int,
     ) -> None:
         """Remove (library) item from the favorites."""
         await self.client.send_command(
             "music/favorites/remove_item",
             media_type=media_type,
-            item_id=item_id,
+            library_item_id=library_item_id,
         )
 
     async def remove_item_from_library(
-        self, media_type: MediaType, library_item_id: str | int
+        self, media_type: MediaType, library_item_id: str | int, recursive: bool = True
     ) -> None:
         """
         Remove item from the library.
@@ -706,6 +757,7 @@ class Music:
             "music/library/remove_item",
             media_type=media_type,
             library_item_id=library_item_id,
+            recursive=recursive,
         )
 
     async def add_item_to_library(
@@ -732,20 +784,42 @@ class Music:
         self,
         media_item: MediaItemType,
         fully_played: bool = True,
+        userid: str | None = None,
     ) -> None:
-        """Mark item as played in playlog."""
+        """
+        Mark item as played in playlog.
+
+        :param media_item: The media item to mark as played.
+        :param fully_played: If True, mark the item as fully played.
+        :param userid: Optionally attribute this play to a specific user (instead of the user
+            the client is authenticated as). Requires the authenticated client to have
+            sufficient permissions.
+        """
         await self.client.send_command(
             "music/mark_played",
             media_item=media_item,
             fully_played=fully_played,
+            userid=userid,
         )
 
     async def mark_item_unplayed(
         self,
         media_item: MediaItemType,
+        userid: str | None = None,
     ) -> None:
-        """Mark item as unplayed in playlog."""
-        await self.client.send_command("music/mark_unplayed", media_item=media_item)
+        """
+        Mark item as unplayed in playlog.
+
+        :param media_item: The media item to mark as unplayed.
+        :param userid: Optionally apply this to a specific user (instead of the user the
+            client is authenticated as). Requires the authenticated client to have sufficient
+            permissions.
+        """
+        await self.client.send_command(
+            "music/mark_unplayed",
+            media_item=media_item,
+            userid=userid,
+        )
 
     async def get_track_by_name(
         self,
@@ -885,8 +959,32 @@ class Music:
         artist: str | None = None,
         album: str | None = None,
         media_type: MediaType | None = None,
+        username: str | None = None,
     ) -> MediaItemType | ItemMapping | None:
-        """Try to find a media item (such as a playlist) by name."""
+        """
+        Try to find a media item (such as a playlist) by name.
+
+        :param username: Optionally perform the lookup on behalf of this user (instead of the
+            user the client is authenticated as). Requires the authenticated client to have
+            sufficient permissions. Only honored by the native server lookup (schema >= 33);
+            the legacy fallback always runs as the authenticated user.
+        """
+        assert self.client.server_info  # for type checking
+        if self.client.server_info.schema_version >= 33:
+            # from schema version 33+, the server can handle this natively
+            if result := await self.client.send_command(
+                "music/item_by_name",
+                name=name,
+                artist=artist,
+                album=album,
+                media_type=media_type,
+                username=username,
+            ):
+                return media_from_dict(result)
+            return None
+
+        # Fallback implementation for older server versions.
+        # TODO: remove this after a while, once all/most servers are updated
         # pylint: disable=too-many-nested-blocks
         searchname = name.lower()
         library_functions = [

--- a/music_assistant_client/player_queues.py
+++ b/music_assistant_client/player_queues.py
@@ -189,6 +189,8 @@ class PlayerQueues:
         option: QueueOption | None = None,
         radio_mode: bool = False,
         start_item: str | None = None,
+        username: str | None = None,
+        sort_by: str | None = None,
     ) -> None:
         """
         Play media item(s) on the given queue.
@@ -197,6 +199,10 @@ class PlayerQueues:
         - queue_opt: Which enqueue mode to use.
         - radio_mode: Enable radio mode for the given item(s).
         - start_item: Optional item to start the playlist or album from.
+        - username: Optionally attribute the playback to this user (instead of the user the
+          client is authenticated as), e.g. for playback history when triggered from automation.
+          Requires the authenticated client to have sufficient permissions.
+        - sort_by: Optional sort key to order tracks before applying start_item.
         """
         await self.client.send_command(
             "player_queues/play_media",
@@ -205,6 +211,8 @@ class PlayerQueues:
             option=option,
             radio_mode=radio_mode,
             start_item=start_item,
+            username=username,
+            sort_by=sort_by,
         )
 
     async def transfer(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.133", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.139", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"


### PR DESCRIPTION
## What & why

The client had drifted behind the server: it was pinned to API schema 31 while the server is now at 33. In that gap several commands gained new arguments, a couple were renamed, some client methods sent stale or incorrect arguments, and the new localization and image-palette features (plus the long-lived-token impersonation arguments) were missing. This brings the client back in line with schema 33.

## Changes

- Bump API schema 31 → 33 and `music_assistant_models` 1.1.133 → 1.1.139
- Add new commands: image palette (`get_image_palette`, schema 32), localization (`get_locales` / `set_locale`, schema 33), `verify_item_uri` and a native `get_item_by_name` (schema 33, with a fallback for older servers)
- Declare an optional UI `locale` on connect so the server can localize its strings (schema 33)
- Fix wrong/renamed arguments: `favorites/remove_item` (`item_id` → `library_item_id`), `auth/user/unlink_provider` (`link_id` → `user_id` + `provider_type`), and drop the removed `old_password` from `auth/user/update`
- Add missing arguments across `config`, `music`, `auth` and `player_queues` commands (e.g. `default` / `unpack_splitted_values`, `recursive`, `all_users`, `player_filter` / `provider_filter`, `sort_by`, `played_after_timestamp`)
- Expose `username` / `userid` impersonation on the relevant commands for clients using a long-lived token to act on behalf of a user (noted as requiring sufficient permissions)
- Refresh outdated docstrings to match the server
