### PR TITLE
Keep cached queue elapsed_time in sync on QUEUE_TIME_UPDATED

### DIFF
--- a/music_assistant_client/player_queues.py
+++ b/music_assistant_client/player_queues.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import EventType, QueueOption, RepeatMode
@@ -29,6 +30,7 @@ class PlayerQueues:
             (
                 EventType.QUEUE_ADDED,
                 EventType.QUEUE_UPDATED,
+                EventType.QUEUE_TIME_UPDATED,
             ),
         )
         # the initial items are retrieved after connect
@@ -255,6 +257,12 @@ class PlayerQueues:
             # Queue events always have an object_id
             assert event.object_id
             self._queues[event.object_id] = PlayerQueue.from_dict(event.data)
+        elif event.event == EventType.QUEUE_TIME_UPDATED:
+            # keep the cached elapsed time in sync so consumers don't read a stale value
+            assert event.object_id
+            if queue := self._queues.get(event.object_id):
+                queue.elapsed_time = float(event.data)
+                queue.elapsed_time_last_updated = time.time()
 
     def __iter__(self) -> Iterator[PlayerQueue]:
         """Iterate over (available) PlayerQueues."""


### PR DESCRIPTION
## Problem

The client only refreshes a cached `PlayerQueue` on `QUEUE_ADDED` / `QUEUE_UPDATED`. Lightweight `QUEUE_TIME_UPDATED` events (emitted by the server on seeks and other time jumps) were never applied to the cache, so `queue.elapsed_time` went stale.

Consumers that read `queue.elapsed_time` — notably the Home Assistant `music_assistant` media_player, which re-derives `media_position` from it on every `QUEUE_TIME_UPDATED` — kept showing a stale position after seeking until the next full queue update.

## Changes

- Subscribe to `EventType.QUEUE_TIME_UPDATED` in `PlayerQueues`.
- On that event, update the cached queue's `elapsed_time` and `elapsed_time_last_updated`.

## Context

Part of the fix for the Squeezelite progress-bar issue (music-assistant/support#3704). Companion PRs:

- aioslimproto (root fix): music-assistant/aioslimproto#530
- server (revert of the superseded workaround): music-assistant/server#4517