### PR TITLE
chore(deps): bump models to 1.1.150 for player media album_artist and version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.146", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.150", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"


### PR DESCRIPTION
## What
Bump `music_assistant_models` pin from `1.1.146` to `1.1.150`.

## Why
`PlayerMedia` gained `album_artist` and `version` fields (music-assistant/models#286). Bumping the pin makes them available through the client, so consumers (the Home Assistant integration) can read them from `current_media` instead of re-deriving from the queue.