### PR TITLE
chore(deps): bump models to 1.1.151

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.150", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.151", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"


### PR DESCRIPTION
## What
Bump `music_assistant_models` pin from `1.1.150` to `1.1.151`.

## Why
1.1.151 drops the unused `PlayerMedia.version` field (music-assistant/models#287). Keeps the client's models in sync so downstream consumers (the Home Assistant integration) resolve the same version.