### PR TITLE
Add user argument for impersonation to search, library listings and playback

### DIFF
--- a/music_assistant_client/helpers.py
+++ b/music_assistant_client/helpers.py
@@ -11,12 +11,26 @@ from typing import TYPE_CHECKING, Any
 import orjson
 
 if TYPE_CHECKING:
+    from music_assistant_models.api import ServerInfoMessage
     from music_assistant_models.media_items import SearchResults
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
 JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
 
 DO_NOT_SERIALIZE_TYPES = (MethodType, asyncio.Task)
+
+
+def impersonation_arg(server_info: ServerInfoMessage | None, user: str | None) -> dict[str, Any]:
+    """
+    Return the impersonation argument for an API command.
+
+    :param server_info: The connected server's info (to determine the schema version).
+    :param user: The user_id or username of the user to impersonate (or None).
+    """
+    if server_info is not None and server_info.schema_version >= 35:
+        return {"user": user}
+    # older servers only accept the username argument on selected commands
+    return {"username": user}
 
 
 def compact_media_item_dict(item: dict[str, Any]) -> dict[str, Any]:

--- a/music_assistant_client/music.py
+++ b/music_assistant_client/music.py
@@ -25,6 +25,8 @@ from music_assistant_models.media_items import (
     media_from_dict,
 )
 
+from .helpers import impersonation_arg
+
 if TYPE_CHECKING:
     from music_assistant_models.queue_item import QueueItem
 
@@ -48,6 +50,7 @@ class Music:
         offset: int | None = None,
         order_by: str | None = None,
         provider: str | list[str] | None = None,
+        user: str | None = None,
     ) -> list[Track]:
         """Get Track listing from the server.
 
@@ -57,6 +60,8 @@ class Music:
         :param offset: Number of items to skip.
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID or domain (single string or list).
+        :param user: Optionally execute the request on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return [
             Track.from_dict(obj)
@@ -68,6 +73,8 @@ class Music:
                 offset=offset,
                 order_by=order_by,
                 provider=provider,
+                user=user,
+                require_schema=35 if user else None,
             )
         ]
 
@@ -140,6 +147,7 @@ class Music:
         order_by: str | None = None,
         album_types: list[AlbumType] | None = None,
         provider: str | list[str] | None = None,
+        user: str | None = None,
     ) -> list[Album]:
         """Get Albums listing from the server.
 
@@ -150,6 +158,8 @@ class Music:
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param album_types: Filter by album types.
         :param provider: Filter by provider instance ID or domain (single string or list).
+        :param user: Optionally execute the request on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return [
             Album.from_dict(obj)
@@ -162,6 +172,8 @@ class Music:
                 order_by=order_by,
                 album_types=album_types,
                 provider=provider,
+                user=user,
+                require_schema=35 if user else None,
             )
         ]
 
@@ -222,6 +234,7 @@ class Music:
         order_by: str | None = None,
         album_artists_only: bool = False,
         provider: str | list[str] | None = None,
+        user: str | None = None,
     ) -> list[Artist]:
         """Get Artists listing from the server.
 
@@ -232,6 +245,8 @@ class Music:
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param album_artists_only: Only return artists that have albums.
         :param provider: Filter by provider instance ID or domain (single string or list).
+        :param user: Optionally execute the request on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return [
             Artist.from_dict(obj)
@@ -244,6 +259,8 @@ class Music:
                 order_by=order_by,
                 album_artists_only=album_artists_only,
                 provider=provider,
+                user=user,
+                require_schema=35 if user else None,
             )
         ]
 
@@ -305,6 +322,7 @@ class Music:
         offset: int | None = None,
         order_by: str | None = None,
         provider: str | list[str] | None = None,
+        user: str | None = None,
     ) -> list[Playlist]:
         """Get Playlists listing from the server.
 
@@ -314,6 +332,8 @@ class Music:
         :param offset: Number of items to skip.
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID or domain (single string or list).
+        :param user: Optionally execute the request on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return [
             Playlist.from_dict(obj)
@@ -325,6 +345,8 @@ class Music:
                 offset=offset,
                 order_by=order_by,
                 provider=provider,
+                user=user,
+                require_schema=35 if user else None,
             )
         ]
 
@@ -403,6 +425,7 @@ class Music:
         offset: int | None = None,
         order_by: str | None = None,
         provider: str | list[str] | None = None,
+        user: str | None = None,
     ) -> list[Audiobook]:
         """Get Audiobooks listing from the server.
 
@@ -412,6 +435,8 @@ class Music:
         :param offset: Number of items to skip.
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID or domain (single string or list).
+        :param user: Optionally execute the request on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return [
             Audiobook.from_dict(obj)
@@ -423,6 +448,8 @@ class Music:
                 offset=offset,
                 order_by=order_by,
                 provider=provider,
+                user=user,
+                require_schema=35 if user else None,
             )
         ]
 
@@ -450,6 +477,7 @@ class Music:
         offset: int | None = None,
         order_by: str | None = None,
         provider: str | list[str] | None = None,
+        user: str | None = None,
     ) -> list[Podcast]:
         """Get Podcasts listing from the server.
 
@@ -459,6 +487,8 @@ class Music:
         :param offset: Number of items to skip.
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID or domain (single string or list).
+        :param user: Optionally execute the request on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return [
             Podcast.from_dict(obj)
@@ -470,6 +500,8 @@ class Music:
                 offset=offset,
                 order_by=order_by,
                 provider=provider,
+                user=user,
+                require_schema=35 if user else None,
             )
         ]
 
@@ -512,6 +544,7 @@ class Music:
         offset: int | None = None,
         order_by: str | None = None,
         provider: str | list[str] | None = None,
+        user: str | None = None,
     ) -> list[Radio]:
         """Get Radio listing from the server.
 
@@ -521,6 +554,8 @@ class Music:
         :param offset: Number of items to skip.
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID or domain (single string or list).
+        :param user: Optionally execute the request on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return [
             Radio.from_dict(obj)
@@ -532,6 +567,8 @@ class Music:
                 offset=offset,
                 order_by=order_by,
                 provider=provider,
+                user=user,
+                require_schema=35 if user else None,
             )
         ]
 
@@ -584,12 +621,15 @@ class Music:
         media_types: list[MediaType] = MediaType.ALL,
         limit: int = 50,
         library_only: bool = False,
+        user: str | None = None,
     ) -> SearchResults:
         """Perform global search for media items on all providers.
 
         :param search_query: Search query.
         :param media_types: A list of media_types to include.
         :param limit: number of items to return in the search (per type).
+        :param user: Optionally execute the search on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
         """
         return SearchResults.from_dict(
             await self.client.send_command(
@@ -598,6 +638,8 @@ class Music:
                 media_types=media_types,
                 limit=limit,
                 library_only=library_only,
+                user=user,
+                require_schema=35 if user else None,
             ),
         )
 
@@ -676,21 +718,23 @@ class Music:
         """Get single music item providing a mediaitem uri."""
         return media_from_dict(await self.client.send_command("music/item_by_uri", uri=uri))
 
-    async def verify_item_uri(self, uri: str, username: str | None = None) -> bool:
+    async def verify_item_uri(
+        self, uri: str, user: str | None = None, username: str | None = None
+    ) -> bool:
         """
         Verify whether a uri points to a valid, accessible item.
 
-        :param username: Optionally verify access on behalf of this user (instead of the
-            user the client is authenticated as). Requires the authenticated client to have
-            sufficient permissions.
+        :param user: Optionally verify access on behalf of this user (user_id or username).
+            Requires the authenticated client to have sufficient permissions.
+        :param username: Deprecated alias for user.
         """
         return cast(
             "bool",
             await self.client.send_command(
                 "music/verify_item_uri",
                 uri=uri,
-                username=username,
                 require_schema=33,
+                **impersonation_arg(self.client.server_info, user or username),
             ),
         )
 
@@ -959,15 +1003,17 @@ class Music:
         artist: str | None = None,
         album: str | None = None,
         media_type: MediaType | None = None,
+        user: str | None = None,
         username: str | None = None,
     ) -> MediaItemType | ItemMapping | None:
         """
         Try to find a media item (such as a playlist) by name.
 
-        :param username: Optionally perform the lookup on behalf of this user (instead of the
-            user the client is authenticated as). Requires the authenticated client to have
-            sufficient permissions. Only honored by the native server lookup (schema >= 33);
-            the legacy fallback always runs as the authenticated user.
+        :param user: Optionally perform the lookup on behalf of this user (user_id or
+            username). Requires the authenticated client to have sufficient permissions.
+            Only honored by the native server lookup (schema >= 33); the legacy fallback
+            always runs as the authenticated user.
+        :param username: Deprecated alias for user.
         """
         assert self.client.server_info  # for type checking
         if self.client.server_info.schema_version >= 33:
@@ -978,7 +1024,7 @@ class Music:
                 artist=artist,
                 album=album,
                 media_type=media_type,
-                username=username,
+                **impersonation_arg(self.client.server_info, user or username),
             ):
                 return media_from_dict(result)
             return None

--- a/music_assistant_client/player_queues.py
+++ b/music_assistant_client/player_queues.py
@@ -9,6 +9,8 @@ from music_assistant_models.enums import EventType, QueueOption, RepeatMode
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
+from .helpers import impersonation_arg
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -206,6 +208,7 @@ class PlayerQueues:
         option: QueueOption | None = None,
         radio_mode: bool = False,
         start_item: str | None = None,
+        user: str | None = None,
         username: str | None = None,
         sort_by: str | None = None,
     ) -> None:
@@ -218,9 +221,10 @@ class PlayerQueues:
           seed item(s) are translated client-side to a radio_playlist:// dynamic playlist (see
           radio_playlist_uri); older servers still receive the flag. Prefer passing such a uri.
         - start_item: Optional item to start the playlist or album from.
-        - username: Optionally attribute the playback to this user (instead of the user the
-          client is authenticated as), e.g. for playback history when triggered from automation.
-          Requires the authenticated client to have sufficient permissions.
+        - user: Optionally attribute the playback to this user (user_id or username), e.g. for
+          playback history when triggered from automation. Requires the authenticated client
+          to have sufficient permissions.
+        - username: Deprecated alias for user.
         - sort_by: Optional sort key to order tracks before applying start_item.
         """
         if (
@@ -241,8 +245,8 @@ class PlayerQueues:
             option=option,
             radio_mode=radio_mode,
             start_item=start_item,
-            username=username,
             sort_by=sort_by,
+            **impersonation_arg(self.client.server_info, user or username),
         )
 
     async def transfer(


### PR DESCRIPTION
## What does this implement/fix?

Companion to music-assistant/server#4613 (scope based authorization + centralized impersonation). The server now accepts an optional `user` argument (user_id or username) on impersonation-enabled commands, handled centrally in the command dispatch.

- `search` and all `get_library_*` listing methods accept an optional `user` argument (gated on schema 35, so it raises on older servers instead of silently ignoring it)
- `play_media`, `get_item_by_name` and `verify_item_uri` gain `user` alongside the now-deprecated `username` alias; a small helper picks the right wire argument based on the server's schema version so older servers keep working
- impersonating another user requires the `users.impersonate` scope on the server side (granted to the Home Assistant system user via the new service role)

Requires server schema 35 for the new commands (music-assistant/server#4622).