### PR TITLE
Add audio processing chain support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,20 @@ jobs:
           pip install . .[test]
       - name: Lint/test with pre-commit
         run: SKIP=no-commit-to-branch pre-commit run --all-files
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build setuptools
+          pip install . .[test]
+      - name: Run tests
+        run: python -m unittest

--- a/music_assistant_client/constants.py
+++ b/music_assistant_client/constants.py
@@ -2,4 +2,4 @@
 
 from typing import Final
 
-API_SCHEMA_VERSION: Final[int] = 33
+API_SCHEMA_VERSION: Final[int] = 38

--- a/music_assistant_client/player_queues.py
+++ b/music_assistant_client/player_queues.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any
 
+from music_assistant_models.audio_processing import AudioProcessingChain
 from music_assistant_models.enums import EventType, QueueOption, RepeatMode
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
@@ -18,6 +20,12 @@ if TYPE_CHECKING:
     from music_assistant_models.media_items import ItemMapping, MediaItemType
 
     from .client import MusicAssistantClient
+
+
+AudioProcessingCallback = Callable[
+    [str, AudioProcessingChain | None],
+    Coroutine[Any, Any, None] | None,
+]
 
 
 def radio_playlist_uri(seed: MediaItemType | ItemMapping | str) -> str:
@@ -85,6 +93,37 @@ class PlayerQueues:
         if player := self.client.players.get(player_id):
             return self.get(player.active_source or player.player_id)
         return None
+
+    async def get_audio_processing_chain(self, queue_id: str) -> AudioProcessingChain | None:
+        """Return the current audio processing snapshot for a queue."""
+        result = await self.client.send_command(
+            "player_queues/audio_processing_chain",
+            queue_id=queue_id,
+            require_schema=38,
+        )
+        if result is None:
+            return None
+        return AudioProcessingChain.from_dict(result)
+
+    def subscribe_audio_processing(
+        self,
+        callback: AudioProcessingCallback,
+        queue_id: str | tuple[str, ...] | None = None,
+    ) -> Callable[[], None]:
+        """Subscribe to complete audio processing snapshots and clear events."""
+
+        async def handle_event(event: MassEvent) -> None:
+            assert event.object_id
+            chain = None if event.data is None else AudioProcessingChain.from_dict(event.data)
+            callback_result = callback(event.object_id, chain)
+            if callback_result is not None:
+                await callback_result
+
+        return self.client.subscribe(
+            handle_event,
+            EventType.AUDIO_PROCESSING_UPDATED,
+            queue_id,
+        )
 
     async def play(self, queue_id: str) -> None:
         """Send PLAY command to given queue."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.152", "orjson>=3.9"]
+dependencies = ["aiohttp>=3.8.6", "music_assistant_models==1.1.161", "orjson>=3.9"]
 description = "Music Assistant Client"
 license = {text = "Apache-2.0"}
 name = "music_assistant_client"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Music Assistant client."""

--- a/tests/test_player_queues.py
+++ b/tests/test_player_queues.py
@@ -1,0 +1,117 @@
+"""Tests for player queue endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, Mock
+
+from music_assistant_models.api import ServerInfoMessage
+from music_assistant_models.audio_processing import AudioProcessingChain
+from music_assistant_models.enums import EventType
+from music_assistant_models.event import MassEvent
+
+from music_assistant_client.client import MusicAssistantClient
+from music_assistant_client.exceptions import InvalidServerVersion
+from music_assistant_client.player_queues import PlayerQueues
+
+AUDIO_PROCESSING_DATA: dict[str, Any] = {
+    "queue_id": "queue-1",
+    "queue_item_id": "item-1",
+    "revision": 4,
+    "state": "ready",
+    "outputs": [{"player_ids": ["player-1"]}],
+}
+
+
+def create_player_queues(
+    command_result: dict[str, Any] | None,
+) -> tuple[PlayerQueues, AsyncMock, Mock]:
+    """Create a player queue controller with a mocked client."""
+    client = Mock(spec=MusicAssistantClient)
+    send_command = AsyncMock(return_value=command_result)
+    client.send_command = send_command
+    controller = PlayerQueues(cast("MusicAssistantClient", client))
+    return controller, send_command, client.subscribe
+
+
+class PlayerQueuesTest(IsolatedAsyncioTestCase):
+    """Test player queue endpoints."""
+
+    async def test_get_audio_processing_chain(self) -> None:
+        """Test command arguments and result parsing."""
+        controller, send_command, _ = create_player_queues(AUDIO_PROCESSING_DATA)
+
+        result = await controller.get_audio_processing_chain("queue-1")
+
+        send_command.assert_awaited_once_with(
+            "player_queues/audio_processing_chain",
+            queue_id="queue-1",
+            require_schema=38,
+        )
+        assert isinstance(result, AudioProcessingChain)
+        assert result.queue_id == "queue-1"
+        assert result.revision == 4
+        assert result.outputs[0].player_ids == ["player-1"]
+
+    async def test_get_audio_processing_chain_returns_none(self) -> None:
+        """Test a missing audio processing snapshot."""
+        controller, _, _ = create_player_queues(None)
+
+        assert await controller.get_audio_processing_chain("queue-1") is None
+
+    async def test_subscribe_audio_processing(self) -> None:
+        """Test typed full snapshot and clear events."""
+        controller, _, subscribe = create_player_queues(None)
+        unsubscribe = Mock()
+        subscribe.return_value = unsubscribe
+        updates: list[tuple[str, AudioProcessingChain | None]] = []
+
+        async def handle_update(queue_id: str, chain: AudioProcessingChain | None) -> None:
+            updates.append((queue_id, chain))
+
+        remove_listener = controller.subscribe_audio_processing(handle_update, "queue-1")
+        event_handler: Callable[[MassEvent], Any] = subscribe.call_args.args[0]
+
+        await event_handler(
+            MassEvent(
+                event=EventType.AUDIO_PROCESSING_UPDATED,
+                object_id="queue-1",
+                data=AUDIO_PROCESSING_DATA,
+            )
+        )
+        await event_handler(
+            MassEvent(
+                event=EventType.AUDIO_PROCESSING_UPDATED,
+                object_id="queue-1",
+                data=None,
+            )
+        )
+
+        assert remove_listener is unsubscribe
+        assert subscribe.call_args.args[1:] == (
+            EventType.AUDIO_PROCESSING_UPDATED,
+            "queue-1",
+        )
+        assert updates[0][0] == "queue-1"
+        assert isinstance(updates[0][1], AudioProcessingChain)
+        assert updates[0][1].revision == 4
+        assert updates[1] == ("queue-1", None)
+
+    async def test_audio_processing_chain_requires_schema_38(self) -> None:
+        """Test rejection by servers without audio processing support."""
+        client = MusicAssistantClient("http://example.test", Mock())
+        client.connection = Mock()
+        client.connection.connected = True
+        client._server_info = ServerInfoMessage(  # noqa: SLF001
+            server_id="server",
+            server_version="0.0.0",
+            schema_version=37,
+            min_supported_schema_version=33,
+        )
+
+        with self.assertRaisesRegex(InvalidServerVersion, "api schema 38"):  # noqa: PT027
+            await client.player_queues.get_audio_processing_chain("queue-1")
+
+        client.connection.send_message.assert_not_called()


### PR DESCRIPTION
Clients need a typed way to retrieve and follow the server's complete audio processing path.

- Add the schema-gated audio processing command
- Add typed full-snapshot and clear-event subscriptions
- Add required unittest coverage and CI enforcement