### PR TITLE
Include protocol players in initial player state sync

### DIFF
--- a/music_assistant_client/players.py
+++ b/music_assistant_client/players.py
@@ -412,8 +412,9 @@ class Players:
         )
 
     async def _get_players(self) -> list[Player]:
-        """Fetch all Players from the server."""
-        return [Player.from_dict(item) for item in await self.client.send_command("players/all")]
+        """Fetch all Players from the server, including protocol players exposed to clients."""
+        players = await self.client.send_command("players/all", return_protocol_players=True)
+        return [Player.from_dict(item) for item in players]
 
     async def fetch_state(self) -> None:
         """Fetch initial state once the server is connected."""


### PR DESCRIPTION
Closes #205.

Protocol players exposed to Home Assistant (e.g. a Squeezelite player via
SlimProto) are excluded from the `players/all` response by default, so they
never entered the client's initial cache. As a result, HA's Music Assistant
integration could not create their `media_player` entities during the initial
sync/reconnect, even though the player was healthy and enabled in MA.

`players._get_players()` now passes `return_protocol_players=True`, so exposed
protocol players are present in the initial hydration. The server's `players/all`
command exposes exactly this flag (`return_protocol_players: bool = False`,
documented as "Include protocol players, hidden by default").

Downstream consumers such as the HA integration already filter by `expose_to_ha`,
so including protocol players here is safe and matches HA's own handling.