### PR TITLE
Fix REST login for newer Music Assistant servers

### DIFF
--- a/music_assistant_client/auth_helpers.py
+++ b/music_assistant_client/auth_helpers.py
@@ -62,10 +62,17 @@ async def login(
         server_url = f"{server_url}/"
 
     try:
-        # Send login request
+        # Send login request.
+        # Recent servers (~API 2.8.4+) read credentials from a nested
+        # "credentials" object; older servers read the flat username/password
+        # fields. Send both shapes so the client works across server versions.
         async with session.post(
             f"{server_url}auth/login",
-            json={"username": username, "password": password},
+            json={
+                "username": username,
+                "password": password,
+                "credentials": {"username": username, "password": password},
+            },
         ) as response:
             if response.status == 401:
                 msg = "Invalid username or password"
@@ -77,7 +84,9 @@ async def login(
 
             data = await response.json()
             user = User.from_dict(data["user"])
-            access_token = data["access_token"]
+            # Recent servers return the token under "token"; older servers used
+            # "access_token". Accept either for backward compatibility.
+            access_token = data.get("token", data.get("access_token"))
 
             LOGGER.info("Successfully logged in as %s", username)
             return user, access_token

--- a/music_assistant_client/auth_helpers.py
+++ b/music_assistant_client/auth_helpers.py
@@ -87,6 +87,9 @@ async def login(
             # Recent servers return the token under "token"; older servers used
             # "access_token". Accept either for backward compatibility.
             access_token = data.get("token", data.get("access_token"))
+            if access_token is None:
+                msg = "Login response did not contain an access token"
+                raise LoginFailed(msg)
 
             LOGGER.info("Successfully logged in as %s", username)
             return user, access_token


### PR DESCRIPTION
Closes #170.

Recent Music Assistant servers (~API 2.8.4+) changed the `/auth/login` REST
contract: they read credentials from a nested `credentials` object and return
the session token under `token` instead of `access_token`. The client sent a
flat `{username, password}` body and read `data["access_token"]`, so login
fails against current servers.

This updates `auth_helpers.login()` to:

- Send the credentials nested under `credentials`, and
- Read the token via `token`, falling back to `access_token`.

The flat `username`/`password` fields are still sent so older servers that read
them directly keep working — i.e. the change is backward compatible.

Verified against the server's `_handle_auth_login` handler, which reads
`body["credentials"]` and returns `{"success", "token", "user"}`.