### PR TITLE
Fix committing from a git worktree

### DIFF
--- a/scripts/run-in-env.sh
+++ b/scripts/run-in-env.sh
@@ -12,11 +12,22 @@ fi
 # other common virtualenvs
 my_path=$(git rev-parse --show-toplevel)
 
-for venv in venv .venv .; do
-  if [ -f "${my_path}/${venv}/bin/activate" ]; then
-    . "${my_path}/${venv}/bin/activate"
-    break
-  fi
+# A git worktree usually has no virtualenv of its own, so search the main checkout as well.
+# A worktree's git dir differs from the common git dir, which lives in the main checkout.
+git_dir=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null || true)
+common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+main_root=""
+if [ -n "$common_dir" ] && [ "$git_dir" != "$common_dir" ]; then
+  main_root=$(dirname "$common_dir")
+fi
+
+for root in "$my_path" ${main_root:+"$main_root"}; do
+  for venv in venv .venv .; do
+    if [ -f "${root}/${venv}/bin/activate" ]; then
+      . "${root}/${venv}/bin/activate"
+      break 2
+    fi
+  done
 done
 
 exec "$@"


### PR DESCRIPTION
Committing from a git worktree did not work: the pre-commit helper script looks for the virtual environment in the current checkout, and a worktree does not have one. Nothing got activated, so the hooks could not start `ruff`/`mypy` and the commit was aborted. The only way around it was to point `PATH` at the main checkout's `.venv` by hand.

The helper now detects a worktree and falls back to the main checkout's virtual environment.

- Detect a worktree by comparing the git dir with the common git dir
- Fall back to the main checkout when the worktree has no virtual environment of its own
- A virtual environment in the worktree itself still takes precedence, and a normal checkout behaves exactly as before

Same fix as music-assistant/models#354.
