### PR TITLE
Add package URLs metadata and release 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ test = [
   "ruff==0.15.10",
 ]
 
+[project.urls]
+"Homepage" = "https://www.music-assistant.io"
+"Issue Tracker" = "https://github.com/music-assistant/support/issues"
+"Repository" = "https://github.com/music-assistant/client"
+
 [tool.setuptools]
 include-package-data = true
 packages = ["music_assistant_client"]


### PR DESCRIPTION
## What does this implement/fix?

Home Assistant core's PR to bump `music-assistant-client` ([home-assistant/core#179386](https://github.com/home-assistant/core/pull/179386)) needs a client release that both drops the GPL dependency and is traceable by HA's requirements bot:

- The models bump to `1.1.189` is already on `main` (#248). That release replaces GPLv2+ `unidecode` with ISC `anyascii` ([models#364](https://github.com/music-assistant/models/pull/364)), which unblocks HA's license audit.
- The published `1.5.0` wheel has no `Project-URL` metadata, so HA's requirements bot flags the dependency as untraceable. This adds `[project.urls]` (homepage, repository, issue tracker).
- The commits merged since `1.5.0` use no conventional prefixes, so release-please has nothing to release. The `Release-As: 1.5.1` commit forces the release, following the convention used for 1.4.1, 1.4.2 and 1.5.0.

## Changes

- Add `[project.urls]` to `pyproject.toml` so the built wheel carries `Project-URL` metadata
- Empty `chore: release 1.5.1` commit with a `Release-As: 1.5.1` footer to trigger release-please

Verified locally: a wheel built the way `release.yml` builds it carries the three `Project-URL` fields and pins `music_assistant_models==1.1.189`, whose own metadata requires `anyascii==0.3.3` with no `unidecode`.
